### PR TITLE
Fix diagnostics to check Pi Bluetooth adapter instead of browser Web …

### DIFF
--- a/src/web/static/js/device-management.js
+++ b/src/web/static/js/device-management.js
@@ -658,20 +658,34 @@ class DeviceManager {
             bluetooth: await this.checkBluetoothStatus(),
             connection: await this.checkConnectionStatus(),
             dataFlow: await this.checkDataFlow(),
-            system: this.checkSystemInfo()
+            system: await this.checkSystemInfo()
         };
-        
+
         return results;
     }
     
     async checkBluetoothStatus() {
-        // Check if Web Bluetooth API is available
-        const webBluetoothAvailable = 'bluetooth' in navigator;
-        
-        return {
-            webBluetoothSupported: webBluetoothAvailable,
-            status: webBluetoothAvailable ? 'Available' : 'Not supported'
-        };
+        // Query the Raspberry Pi backend for Bluetooth adapter health
+        // (BLE runs on the Pi, not in the phone browser)
+        try {
+            const response = await fetch('/health/detailed');
+            const health = await response.json();
+            const bt = health.components && health.components.bluetooth;
+
+            if (bt) {
+                return {
+                    status: bt.status,
+                    mode: bt.mode || null,
+                    adapters: bt.adapters || [],
+                    adapterCount: bt.adapter_count || 0,
+                    note: bt.note || null,
+                    error: bt.error || null
+                };
+            }
+            return { status: 'unknown', error: 'No Bluetooth info from server' };
+        } catch (error) {
+            return { status: 'error', error: error.message };
+        }
     }
     
     async checkConnectionStatus() {
@@ -721,24 +735,44 @@ class DeviceManager {
         }
     }
     
-    checkSystemInfo() {
-        return {
-            userAgent: navigator.userAgent,
-            platform: navigator.platform,
-            language: navigator.language,
+    async checkSystemInfo() {
+        const info = {
+            browserPlatform: navigator.platform,
             onLine: navigator.onLine,
             cookieEnabled: navigator.cookieEnabled
         };
+
+        // Fetch server-side system info
+        try {
+            const response = await fetch('/health/detailed');
+            const health = await response.json();
+            info.serverStatus = health.status;
+            if (health.components && health.components.memory) {
+                info.serverMemory = health.components.memory;
+            }
+        } catch (e) {
+            info.serverStatus = 'unreachable';
+        }
+
+        return info;
     }
     
     formatDiagnosticResults(diagnostics) {
         let html = `<h6>Diagnostic Results - ${new Date(diagnostics.timestamp).toLocaleString()}</h6>`;
         
-        // Bluetooth Status
+        // Bluetooth Status (Raspberry Pi adapter)
         html += '<div class="mb-3">';
-        html += '<strong>Bluetooth Status:</strong><br>';
-        html += `Web Bluetooth Support: ${diagnostics.bluetooth.webBluetoothSupported ? '✅' : '❌'}<br>`;
-        html += `Status: ${diagnostics.bluetooth.status}<br>`;
+        html += '<strong>Raspberry Pi Bluetooth:</strong><br>';
+        if (diagnostics.bluetooth.error) {
+            html += `Adapter Status: ❌ ${diagnostics.bluetooth.error}<br>`;
+        } else if (diagnostics.bluetooth.mode === 'simulator') {
+            html += 'Adapter Status: ✅ Simulator Mode<br>';
+        } else if (diagnostics.bluetooth.status === 'healthy') {
+            html += `Adapter Status: ✅ Healthy<br>`;
+            html += `Adapters Found: ${diagnostics.bluetooth.adapterCount}<br>`;
+        } else {
+            html += `Adapter Status: ❌ ${diagnostics.bluetooth.status}<br>`;
+        }
         html += '</div>';
         
         // Connection Status
@@ -771,9 +805,13 @@ class DeviceManager {
         // System Info
         html += '<div class="mb-3">';
         html += '<strong>System Information:</strong><br>';
-        html += `Platform: ${diagnostics.system.platform}<br>`;
-        html += `Online: ${diagnostics.system.onLine ? '✅' : '❌'}<br>`;
-        html += `Cookies: ${diagnostics.system.cookieEnabled ? '✅' : '❌'}<br>`;
+        html += `Server Status: ${diagnostics.system.serverStatus === 'healthy' ? '✅ Healthy' : '❌ ' + (diagnostics.system.serverStatus || 'Unknown')}<br>`;
+        if (diagnostics.system.serverMemory && diagnostics.system.serverMemory.system) {
+            const mem = diagnostics.system.serverMemory.system;
+            html += `Server Memory: ${mem.available_gb} GB free of ${mem.total_gb} GB (${mem.used_percent}% used)<br>`;
+        }
+        html += `Network: ${diagnostics.system.onLine ? '✅ Connected' : '❌ Offline'}<br>`;
+        html += `Browser: ${diagnostics.system.browserPlatform}<br>`;
         html += '</div>';
         
         return html;

--- a/src/web/templates/devices.html
+++ b/src/web/templates/devices.html
@@ -153,10 +153,10 @@
                                         <div class="accordion-body">
                                             <ul>
                                                 <li>Ensure your device is powered on and in pairing mode</li>
-                                                <li>Check that Bluetooth is enabled on your computer</li>
-                                                <li>Move closer to the device (within 10 feet)</li>
+                                                <li>Check that Bluetooth is enabled on your Raspberry Pi</li>
+                                                <li>Move the Pi closer to the device (within 10 feet)</li>
                                                 <li>Restart your Rogue Echo equipment</li>
-                                                <li>Check if the device is connected to another app</li>
+                                                <li>Check if the device is connected to another app or phone</li>
                                             </ul>
                                         </div>
                                     </div>
@@ -171,10 +171,10 @@
                                     <div id="collapseTwo" class="accordion-collapse collapse" data-bs-parent="#troubleshootingAccordion">
                                         <div class="accordion-body">
                                             <ul>
-                                                <li>Check for interference from other Bluetooth devices</li>
-                                                <li>Ensure stable power supply to your equipment</li>
-                                                <li>Update your computer's Bluetooth drivers</li>
-                                                <li>Try moving closer to reduce signal interference</li>
+                                                <li>Check for interference from other Bluetooth devices near the Pi</li>
+                                                <li>Ensure stable power supply to your equipment and Raspberry Pi</li>
+                                                <li>Keep the Pi within range of the equipment</li>
+                                                <li>Try restarting the Raspberry Pi service</li>
                                                 <li>Restart the application and try reconnecting</li>
                                             </ul>
                                         </div>


### PR DESCRIPTION
…Bluetooth

The diagnostic page was checking for navigator.bluetooth (Web Bluetooth API) in the phone browser, which will never be available on iOS Safari. Since BLE runs on the Raspberry Pi backend via bleak/pyftms, diagnostics now query the Pi's /health/detailed endpoint for actual adapter status, memory, and health. Also updated troubleshooting text to reference the Pi instead of "your computer".

https://claude.ai/code/session_01CtZ1kbGSZoquFxXAW3ua4K